### PR TITLE
.htaccess: Append AddLanguage

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -11,4 +11,5 @@ AddType application/x-httpd-php pt
 AddType application/x-httpd-php pt_BR
 AddType application/x-httpd-php ru
 AddType application/x-httpd-php zh_CN
-
+AddLanguage pt-br .pt_BR
+AddLanguage zh-cn .zh_CN


### PR DESCRIPTION
Just using AddType doesn't seem to give translated content for web browsers set for Portuguese (Brazil) or Chinese (Simplified) languages. Adding the "AddLanguage" directive with the lowercase-and-dash version of the language codes seems to do the job -- worked for me locally.

About AddLanguage: https://httpd.apache.org/docs/2.4/pt-br/mod/mod_mime.html#addlanguage

This hopefully fixes mquinson/po4a#139