### PR TITLE
Force Content-Type for localized file extensions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,3 +22,9 @@ RUN cp -a src/. html/
 # move result to be published
 # to the OSCI's openshift-apps/php_website role location
 RUN mv html /srv/website
+
+# force Content-Type for localized file extensions
+#
+# Using FileMatch+SetHandler, even with MultiviewsMatch Any did not work with content negociation
+WORKDIR /srv/website
+RUN for f in index.php.*; do echo "AddType application/x-httpd-php ${f##*.}">>.htaccess; done


### PR DESCRIPTION
I thought I had nailed this out in #21 with the newer Apache and new OpenShift config but I was wrong and could not get it to work again, I must have made a mistake.

Instead of just reinstating the previous list of AddHandler calls, let's generate it here in order to avoid some tedious maintenance.